### PR TITLE
fix: update timeout config for Insights apis

### DIFF
--- a/google/cloud/recommender_v1/gapic/recommender_client_config.py
+++ b/google/cloud/recommender_v1/gapic/recommender_client_config.py
@@ -16,15 +16,6 @@ config = {
                     "max_rpc_timeout_millis": 60000,
                     "total_timeout_millis": 60000,
                 },
-                "no_retry_params": {
-                    "initial_retry_delay_millis": 0,
-                    "retry_delay_multiplier": 0.0,
-                    "max_retry_delay_millis": 0,
-                    "initial_rpc_timeout_millis": 0,
-                    "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 0,
-                    "total_timeout_millis": 0,
-                },
                 "no_retry_1_params": {
                     "initial_retry_delay_millis": 0,
                     "retry_delay_multiplier": 0.0,
@@ -39,17 +30,17 @@ config = {
                 "ListInsights": {
                     "timeout_millis": 60000,
                     "retry_codes_name": "retry_policy_1_codes",
-                    "retry_params_name": "no_retry_params",
+                    "retry_params_name": "no_retry_1_params",
                 },
                 "GetInsight": {
                     "timeout_millis": 60000,
                     "retry_codes_name": "retry_policy_1_codes",
-                    "retry_params_name": "no_retry_params",
+                    "retry_params_name": "no_retry_1_params",
                 },
                 "MarkInsightAccepted": {
                     "timeout_millis": 60000,
                     "retry_codes_name": "no_retry_1_codes",
-                    "retry_params_name": "no_retry_params",
+                    "retry_params_name": "no_retry_1_params",
                 },
                 "ListRecommendations": {
                     "timeout_millis": 60000,


### PR DESCRIPTION
Two options to fix #46 are to None the "retry_params_name" field, or to just use "no_retry_1_params" which is effectively a constant timeout. I went with the latter.

By naming the retry_params_name it will instantiate a google.api_core.timeout.ExponentialTimeout object built out of the retry params with 0 timeout leaving the "timeout_millis" in the method ignored. Instead if None is used a ConstantTimeout object is built and the timeout_millis is properly populated. So I don't fully understand why both are here, however using "no_retry_1_params" it is the same end result and leaves it consistent with some other methods.

Fixes #46 🦕