### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ name = "google-cloud-recommender"
 description = "Cloud Recommender API client library"
 version = "2.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.22.2, < 2.0.0dev", "proto-plus >= 1.10.0", "packaging >= 14.3"]
+dependencies = [
+    "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
+    "proto-plus >= 1.10.0",
+    "packaging >= 14.3",
+]
 extras = {"libcst": "libcst >= 0.2.5"}
 scripts = [
     "scripts/fixup_recommender_v1_keywords.py",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ name = "google-cloud-recommender"
 description = "Cloud Recommender API client library"
 version = "2.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.22.2, < 2.0.0dev", "proto-plus >= 1.10.0"]
+dependencies = ["google-api-core[grpc] >= 1.22.2, < 2.0.0dev", "proto-plus >= 1.10.0", "packaging >= 14.3"]
 extras = {"libcst": "libcst >= 0.2.5"}
 scripts = [
     "scripts/fixup_recommender_v1_keywords.py",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -7,3 +7,4 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.22.2
 proto-plus==1.15.0
+packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py and is needed after the upgrade to gapic-generator-python 0.46.3