### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "recommender",
     "name_pretty": "Cloud Recommender API",
     "product_documentation": "https://cloud.google.com/recommender",
-    "client_documentation": "https://googleapis.dev/python/recommender/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/recommender/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ machine learning, and current resource usage.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-recommender.svg
    :target: https://pypi.org/project/google-cloud-recommender/
 .. _Recommender API: https://cloud.google.com/recommender
-.. _Client Library Documentation: https://googleapis.dev/python/recommender/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/recommender/latest
 .. _Product Documentation:  https://cloud.google.com/recommender/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.